### PR TITLE
add wait to launch for compatibility with other container

### DIFF
--- a/cram/with_jupyter/cram_launch.sh
+++ b/cram/with_jupyter/cram_launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /home/workspace/ros/devel/setup.bash
-roslaunch cram_pick_place_tutorial world.launch &
+roslaunch cram_pick_place_tutorial world.launch --wait &
 export THIS_IP=$(ifconfig 'docker0' | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*')
 sleep 2
 echo ""


### PR DESCRIPTION
the wait argument is necessary if another container also launches ros else you get 
```
RLException: run_id on parameter server does not match declared run_id: 8833a8ae-2844-11ed-b6e6-0c9d92c2d729 vs 883d06a6-2844-11ed-a844-0c9d92c2d729
The traceback for the exception was written to the log file
```